### PR TITLE
Setup run time environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ WORKDIR /app
 # Only copy the built code and necessary files
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/dist ./dist
+
+# Add startup script
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
 RUN npm install --production
 RUN npm install -g serve
 
@@ -34,4 +39,4 @@ RUN npm install -g serve
 EXPOSE 8080
 
 # Command to run the built app
-CMD ["serve", "-s", "dist", "-p", "8080"]
+CMD ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -60,3 +60,25 @@ make docker-run-server
 | Environment Variables          | Description                                                                 |
 |-------------------------------|----------------------------------------------------------------------------|
 | `VITE_API_URL`                | URL of the Server [default: `http://localhost:9092`]                       |
+
+
+
+# Runtime Environment Variables
+To enable Dynamic Environment Variables at run time, the following customisations have been applied.
+
+**`.env.js`**
+An `env.js` file has been added to the `public` directory. This is used to load runtime variables on the `window.__RUNTIME_CONFIG__` field.
+
+**`index.html`**
+A script import in the `index.html` file has been added to load the `env.js` file.
+
+**`entrypoint.sh`**
+An `entrypoint` bash script has been setup which replaces variables in the `env.js` file aat run time. The `Dockerfile` now uses this this `entrypoint`  bash script to run the environment variables replacement and tthen start the server.
+
+**`config.ts/config.d.ts`**
+A `config.d.ts` types file has been created for the new `__RUNTIME_CONFIG__` property on the `window` object and the file which loads the environment variables (`config.ts`) now looks for runtime environment variables as well 
+
+
+This appraoch seems slightly hacky/custom, especially considering we are touching the default `index.html` file. Ideally a vite plugin can be used in the future which can handle injecting run time environment variables for us.
+
+- PR: https://github.com/joepk90/graphql-faker-editor/pull/8

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Inject runtime config (to set the VITE_API_URL value at run time)
+cat <<EOF > /app/dist/env.js
+window.__RUNTIME_CONFIG__ = {
+  VITE_API_URL: "${VITE_API_URL}"
+};
+EOF
+
+# Start the app
+exec serve -s dist -p 8080

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
   </head>
   <body>
     <div id="root"></div>
+    <!-- custom: env.j used for runtime variables -->
+    <script src="/env.js"></script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/public/env.js
+++ b/public/env.js
@@ -1,0 +1,4 @@
+// this file is used to inject the VITE_API_URL at runtime (this is custom)
+window.__RUNTIME_CONFIG__ = {
+    VITE_API_URL: ""
+  };

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -1,0 +1,10 @@
+export {};
+
+declare global {
+  interface Window {
+    __RUNTIME_CONFIG__: {
+      VITE_API_URL?: string;
+      [key: string]: any;
+    };
+  }
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,1 +1,2 @@
-export const getApiUrl = () => import.meta.env.VITE_API_URL || 'http://localhost:9092';
+const apiUrl = window.__RUNTIME_CONFIG__?.VITE_API_URL || import.meta.env.VITE_API_URL;
+export const getApiUrl = () => apiUrl || 'http://localhost:9092';


### PR DESCRIPTION
**Runtime Environment Variables Setup**
To enable Dynamic Environment Variables at run time, the following customisations have been applied.

**`.env.js`**
An `env.js` file has been added to the `public` directory. This is used to load runtime variables on the `window.__RUNTIME_CONFIG__` field.

**`index.html`**
A script import in the `index.html` file has been added to load the `env.js` file.

**`entrypoint.sh`**
An `entrypoint` bash script has been setup which replaces variables in the `env.js` file aat run time. The `Dockerfile` now uses this this `entrypoint`  bash script to run the environment variables replacement and tthen start the server.

**`config.ts/config.d.ts`**
A `config.d.ts` types file has been created for the new `__RUNTIME_CONFIG__` property on the `window` object and the file which loads the environment variables (`config.ts`) now looks for runtime environment variables as well 


This appraoch seems slightly hacky/custom, especially considering we are touching the default `index.html` file. Ideally a vite plugin can be used in the future which can handle injecting run time environment variables for us.